### PR TITLE
Fix/whitespace paths

### DIFF
--- a/cesar
+++ b/cesar
@@ -44,9 +44,9 @@ unchanged=0
 for file in "$@"
 do
   if [[ ${file} =~ \.(png|jpe?g)$ ]]; then
-      old_size=$(filesize ${file})
+      old_size=$(filesize "${file}")
       compress "${file}"
-      new_size=$(filesize ${file})
+      new_size=$(filesize "${file}")
 
       if [ "${old_size}" != "${new_size}" ]; then
         echo "compressed $file:" ${old_size} "=>" ${new_size}

--- a/cesar
+++ b/cesar
@@ -10,14 +10,14 @@ require_install () {
 }
 
 # helper function fo handling plural form of message
-file_singular_plural () {              
+file_singular_plural () {
     num_files=$1
-    local res="file" 
-    if (( num_files != 1 )) 
+    local res="file"
+    if (( num_files != 1 ))
     then
-        res+="s"        
+        res+="s"
     fi
-    printf "%s" "$res"  
+    printf "%s" "$res"
 }
 
 # compress input image if it is png or jpeg
@@ -32,8 +32,8 @@ compress () {
 
 # print file human readable size
 filesize() {
-    file=$1  
-    echo $(ls -sh "${file}"|cut -f1 -d " ")  
+    file=$1
+    echo $(ls -sh "${file}"|cut -f1 -d " ")
 }
 
 require_install "pngcrush"

--- a/cesar
+++ b/cesar
@@ -23,9 +23,9 @@ file_singular_plural () {
 # compress input image if it is png or jpeg
 compress () {
     file=$1
-    if [[ ${file} = *.png ]]; then
+    if [[ "$file" = *.png ]]; then
         pngcrush -q -ow -rem alla -brute -reduce "$file"
-    elif [[ ${file} =~ \.(jpe?g)$ ]]; then
+    elif [[ "$file" =~ \.(jpe?g)$ ]]; then
         jpegoptim -q "$file"
     fi
 }
@@ -33,7 +33,7 @@ compress () {
 # print file human readable size
 filesize() {
     file=$1
-    echo $(ls -sh "${file}"|cut -f1 -d " ")
+    echo $(ls -sh "$file" | cut -f1 -d " ")
 }
 
 require_install "pngcrush"
@@ -43,10 +43,10 @@ changed=0
 unchanged=0
 for file in "$@"
 do
-  if [[ ${file} =~ \.(png|jpe?g)$ ]]; then
-      old_size=$(filesize ${file})
-      compress "${file}"
-      new_size=$(filesize ${file})
+  if [[ "$file" =~ \.(png|jpe?g)$ ]]; then
+      old_size=$(filesize "$file")
+      compress "$file"
+      new_size=$(filesize "$file")
 
       if [ "${old_size}" != "${new_size}" ]; then
         echo "compressed $file:" ${old_size} "=>" ${new_size}


### PR DESCRIPTION
*TLDR: Ensures that the file path is always quoted so that the shell won't split the path!*

---

Hi! Thanks for creating this pre-commit script. I am using it for git-syncing of my Obsidian markdown notes. With the exported notes from Joplin, there were spaces in the file names and whitespace was causing errors. Below is an example of the error messages that appear:


```sh
cesar....................................................................Failed
- hook id: cesar
- files were modified by this hook

ls: Georgia: No such file or directory
  Recompressing IDAT chunks in Georgia Tech OMSCS/_resources/f9af22a6766546dfa0242c2ff7f5035b.png
   Total length of data found in critical chunks            =    125379
   Best pngcrush method        = 118 (ws 15 fm 5 zl 9 zs 0) =    125385
CPU time decode 1.569865, encode 8.751231, other 0.038251, total 10.397746 sec
ls: Georgia: No such file or directory
```

And for one-off testing:

```sh
❯ sh cesar.sh Georgia\ Tech\ OMSCS/_resources/284d3b1594344ff7ac1f8d6942bea73e.png
  Recompressing IDAT chunks in Georgia Tech OMSCS/_resources/284d3b1594344ff7ac1f8d6942bea73e.png
   Total length of data found in critical chunks            =    112443
   Best pngcrush method        = 124 (ws 15 fm 5 zl 9 zs 1) =    112449
CPU time decode 0.712141, encode 5.179768, other 0.024742, total 5.933928 sec
```

Then I verified the changes with pre-commit off of my fork:

```yaml
---
repos:
  - repo: https://github.com/KyleKing/cesar
    rev: 981549391947cae57af3598f3bd555febd2b1949
    hooks:
      - id: cesar
```


